### PR TITLE
TP-79/Feature-request-Sales-team-custom-field-discount-percentage

### DIFF
--- a/unpackaged/main/default/objects/Account/fields/DiscountMarketRate__c.field-meta.xml
+++ b/unpackaged/main/default/objects/Account/fields/DiscountMarketRate__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>DiscountMarketRate__c</fullName>
+    <externalId>false</externalId>
+    <label>DiscountMarketRate</label>
+    <precision>18</precision>
+    <required>false</required>
+    <scale>0</scale>
+    <trackFeedHistory>false</trackFeedHistory>
+    <type>Currency</type>
+</CustomField>

--- a/unpackaged/main/default/objects/Account/fields/DiscountPercentage__c.field-meta.xml
+++ b/unpackaged/main/default/objects/Account/fields/DiscountPercentage__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>DiscountPercentage__c</fullName>
+    <externalId>false</externalId>
+    <formula>DiscountRate__c / 100</formula>
+    <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
+    <label>DiscountPercentage</label>
+    <precision>18</precision>
+    <required>false</required>
+    <scale>2</scale>
+    <type>Currency</type>
+</CustomField>

--- a/unpackaged/main/default/objects/Account/fields/DiscountRate__c.field-meta.xml
+++ b/unpackaged/main/default/objects/Account/fields/DiscountRate__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>DiscountRate__c</fullName>
+    <externalId>false</externalId>
+    <formula>DiscountMarketRate__c * 2</formula>
+    <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
+    <label>DiscountRate</label>
+    <precision>18</precision>
+    <required>false</required>
+    <scale>2</scale>
+    <type>Currency</type>
+</CustomField>


### PR DESCRIPTION
## What has changed?
- Added three new custom fields to the Account object:
 - `DiscountMarketRate__c`: A currency field to capture the market discount rate.
 - `DiscountRate__c`: A formula currency field calculating twice the `DiscountMarketRate__c` value.
 - `DiscountPercentage__c`: A formula currency field calculating `DiscountRate__c` divided by 100 with two decimal places.

## What's the impact of these changes?
- Introduces new fields that may affect data entry and reporting on Account records.
- Formula fields depend on `DiscountMarketRate__c`, so blank or zero values will propagate accordingly.
- Potential impact on integrations or processes referencing discount-related fields on Account.
- No direct security or performance concerns as these are standard metadata additions with formulas.

## What should reviewers pay attention to?
- Verify correctness of formula syntax and logic in `DiscountRate__c` and `DiscountPercentage__c`.
- Confirm data type consistency, especially that formula fields are of type Currency.
- Check for any existing automation or integrations that might be affected by these new fields.
- Ensure field labels and API names align with business requirements.

## Testing recommendations
- Manual testing:
 - Create or update Account records with various `DiscountMarketRate__c` values.
 - Validate that `DiscountRate__c` and `DiscountPercentage__c` calculate correctly.
- Regression testing:
 - Review reports, dashboards, and automation that might use discount-related fields.
- Unit tests:
*No unit test classes changed.*